### PR TITLE
Name change

### DIFF
--- a/src/docs/en/component/typography.md
+++ b/src/docs/en/component/typography.md
@@ -12,7 +12,7 @@ title: "Typography"
 
 ## Fonts
 
-The Digital Collaboration Division uses two font families for all digital products: Rubik and Nunito Sans. Both Rubik and Nunito Sans are open source fonts and can be downloaded from [Google Fonts](https://fonts.google.com/) for free.
+Aurora uses two font families for all digital products: Rubik and Nunito Sans. Both Rubik and Nunito Sans are open source fonts and can be downloaded from [Google Fonts](https://fonts.google.com/) for free.
 
 [Rubik](https://fonts.google.com/specimen/Rubik) is used for titles and headings, while [Nunito Sans](https://fonts.google.com/specimen/Nunito+Sans) is used for sub-headings, buttons and paragraph text.
 

--- a/src/docs/en/overview/frequently-asked-questions.md
+++ b/src/docs/en/overview/frequently-asked-questions.md
@@ -19,7 +19,7 @@ Building a design system is a collaborative effort, and requires expertise acros
 
 ## Who created Aurora design system?
 
-Aurora design system is a collaborative effort between various designers, developers and writers across the Government of Canada. Led by the Digital Collaboration Division at the Treasury Board of Canada Secretariat, the system was built in collaboration with the Canadian Digital Service: Talent Cloud, Immigration, Refugees and Citizenship Canada, and other individuals within Government of Canada.
+Aurora design system is a collaborative effort between various designers, developers and writers across the Government of Canada. Led by the Digital Enablement Division at the Treasury Board of Canada Secretariat, the system was built in collaboration with the Canadian Digital Service: Talent Cloud, Immigration, Refugees and Citizenship Canada, and other individuals within Government of Canada.
 
 ## Who can use Aurora design system?
 
@@ -57,11 +57,11 @@ This design system isn’t a direct alternative to WET or the Canada.ca Style Gu
 
 ## How did you build Aurora design system?
 
-The design system was built using the Digital Collaboration Division's existing agile development method. Following our two-week development sprint model, we decided to start separate design sprints on the same cycle. Every two weeks we would pick a particular theme \(i.e. typography, forms\) to work on.
+The design system was built using the Digital Enablement Division's existing agile development method. Following our two-week development sprint model, we decided to start separate design sprints on the same cycle. Every two weeks we would pick a particular theme \(i.e. typography, forms\) to work on.
 
 Pieces were first identified using a handy parts checklist and then listed as separate issues in Github. We managed tasks using an online Kanban board. When files were completed we uploaded them to our Github repository so that they were easily accessible to all members of the team and other partners.
 
-On an ongoing basis, work for the design system will be integrated into existing development cycles within the Digital Collaboration team.
+On an ongoing basis, work for the design system will be integrated into existing development cycles within the Digital Enablement team.
 
 ## Are there files I can download and use?
 

--- a/src/docs/en/overview/introduction.md
+++ b/src/docs/en/overview/introduction.md
@@ -11,7 +11,7 @@ title: "Introduction"
 
 # Introduction
 
-We created Aurora design system to standardize the visual language and user experience of the Digital Collaboration Division’s online applications and tools.
+We created Aurora design system to standardize the visual language and user experience of the Digital Enablement Division’s online applications and tools.
 
 Aurora was built by a multi-disciplinary team of developers, designers, UX researchers, writers and data scientists. Combining the expertise of all of these roles allowed us to create a design system with a wide range of elements.
 

--- a/src/docs/fr/overview/foire-aux-questions.md
+++ b/src/docs/fr/overview/foire-aux-questions.md
@@ -19,7 +19,7 @@ La création d’un système de conception repose sur un effort de collaboration
 
 ## Qui a créé le système de conception Aurora?
 
-Le système de conception Aurora est le fruit d’un partenariat entre divers concepteurs, développeurs et rédacteurs du gouvernement du Canada. Le système a été conçu sous la direction de la Division de la collaboration numérique du Secrétariat du Conseil du Trésor en collaboration avec le Service numérique canadien: le Nuage de talents, Immigration, Réfugiés et Citoyenneté Canada ainsi que d’autres employés du gouvernement du Canada.
+Le système de conception Aurora est le fruit d’un partenariat entre divers concepteurs, développeurs et rédacteurs du gouvernement du Canada. Le système a été conçu sous la direction de la Division de la mobilisation numérique du Secrétariat du Conseil du Trésor en collaboration avec le Service numérique canadien: le Nuage de talents, Immigration, Réfugiés et Citoyenneté Canada ainsi que d’autres employés du gouvernement du Canada.
 
 ## Qui peut utiliser le système de conception Aurora?
 
@@ -53,11 +53,11 @@ Ce système de conception n’est pas une solution de rechange directe à la BOE
 
 ## Comment avez-vous construit le système de conception Aurora?
 
-Le système de conception a été conçu à l’aide la méthode de développement agile de la Division de collaboration numérique. Suite à notre modèle d’itération de développement de deux semaines, nous avons décidé de lancer des itérations de développement distinctes reposant sur le même cycle. Toutes les deux semaines, nous choisissons un thème particulier \(typographie, formes\) sur lequel nous travaillons.
+Le système de conception a été conçu à l’aide la méthode de développement agile de la Division de mobilisation numérique. Suite à notre modèle d’itération de développement de deux semaines, nous avons décidé de lancer des itérations de développement distinctes reposant sur le même cycle. Toutes les deux semaines, nous choisissons un thème particulier \(typographie, formes\) sur lequel nous travaillons.
 
 Les éléments ont d’abord été définis à l’aide d’une liste de contrôle des pièces pratiques, puis répertoriés séparément dans Github. Nous avons géré les tâches à l’aide d’un tableau Kanban en ligne. Les fichiers complétés ont été téléchargés dans notre référentiel Github afin d’être facilement accessibles à tous les membres de l’équipe et aux autres partenaires.
 
-Le travail continu pour le système de conception sera intégré aux cycles de développement actuels de l’équipe de la Collaboration numérique.
+Le travail continu pour le système de conception sera intégré aux cycles de développement actuels de l’équipe de la mobilisation numérique.
 
 ## Puis-je télécharger et utiliser des fichiers?
 

--- a/src/docs/fr/overview/introduction-fr.md
+++ b/src/docs/fr/overview/introduction-fr.md
@@ -11,7 +11,7 @@ title: "Introduction"
 
 # Introduction
 
-Nous avons créé le système de conception Aurora afin de normaliser le langage visuel et l’expérience-utilisateur des applications et des outils créés par la Division de la collaboration numérique.
+Nous avons créé le système de conception Aurora afin de normaliser le langage visuel et l’expérience-utilisateur des applications et des outils créés par la Division de la mobilisation numérique.
 
 Le système Aurora a été créé par une équipe multidisciplinaire composée de concepteurs, de chercheurs EU, de rédacteurs et de scientifiques des données. En combinant l’expertise de tous ces rôles, nous en sommes arrivés à un système de conception doté d’une vaste gamme d’éléments.
 

--- a/src/i18n/locales/en/translation.js
+++ b/src/i18n/locales/en/translation.js
@@ -2,7 +2,7 @@ const enTranslation = {
   "GovernmentofCanada":"Government of Canada",
   "AuroraDesignSystem":"Aurora Design System",
   "Tagline":"Excellent applications need design systems. This is Aurora.",
-  "TopIntro": "Aurora design system is a central design guide created by the Digital Collaboration Division within the Government of Canada for our digital products. Everything you need to create attractive, cohesive, practical, accessible and enjoyable digital products can be found in our design system. Aurora design system will always be free, open, collaborative and evolving.",
+  "TopIntro": "Aurora design system is a central design guide created by the Digital Enablement Division within the Government of Canada for our digital products. Everything you need to create attractive, cohesive, practical, accessible and enjoyable digital products can be found in our design system. Aurora design system will always be free, open, collaborative and evolving.",
   "MainCTA":"Get started",
   "GithubLink":"Find us on GitHub",
   "DownloadLink":"Download Aurora",

--- a/src/i18n/locales/fr/translation.js
+++ b/src/i18n/locales/fr/translation.js
@@ -2,7 +2,7 @@ const frTranslation = {
   "GovernmentofCanada":"Gouvernement du Canada",
   "AuroraDesignSystem":"Système de conception Aurora",
   "Tagline":"D’excellentes applications ont besoin de systèmes de conception. Voici Aurora.",
-  "TopIntro": "Le système de conception Aurora est un guide de conception central créé par la Division de la collaboration numérique du gouvernement du Canada pour nos produits numériques. Tout ce dont vous avez besoin pour créer des produits numériques attrayants, cohésifs, pratiques, accessibles et agréables se trouvent dans notre système de conception. Le système de conception Aurora sera toujours gratuit, ouvert, collaboratif et en évolution.",
+  "TopIntro": "Le système de conception Aurora est un guide de conception central créé par la Division de la mobilisation numérique du gouvernement du Canada pour nos produits numériques. Tout ce dont vous avez besoin pour créer des produits numériques attrayants, cohésifs, pratiques, accessibles et agréables se trouvent dans notre système de conception. Le système de conception Aurora sera toujours gratuit, ouvert, collaboratif et en évolution.",
   "MainCTA":"Commencer",
   "GithubLink":"Trouvez-nous sur Github",
   "DownloadLink":"Téléchargez Aurora",


### PR DESCRIPTION
Went through pages on Aurora and changed "Digital Collaboration Division" to "Digital Enablement Division".

@ethanWallace could you change the name on the home page? It's Digital **Enablement** Division in EN and division de la **mobilisation** numérique in FR